### PR TITLE
Fix typo in modem service class command handler

### DIFF
--- a/lib/ATduck/Modem.pm
+++ b/lib/ATduck/Modem.pm
@@ -362,7 +362,7 @@ sub Z {
     return OK;
 }
 
-sub FCLASS {
+sub FCLA {
     my ($self, $mode, $arg) = @_;
     return ['+FCLASS: 0', 'OK', undef] if $mode == EXT_HELP;
     return [$self->{serviceclass}, 'OK', undef] if $mode == EXT_QUERY;


### PR DESCRIPTION
The handler for `AT+FCLASS` was misnamed as `sub FCLASS`. The parser expects `sub FCLA`. This rename fixes the command handling.